### PR TITLE
Fix syncstatic already updated AUTH_URL in settings

### DIFF
--- a/cumulus/management/commands/syncstatic.py
+++ b/cumulus/management/commands/syncstatic.py
@@ -38,9 +38,6 @@ class Command(BaseCommand):
     if STATIC_URL.startswith('/'):
         STATIC_URL = STATIC_URL[1:]
 
-    if AUTH_URL:
-        AUTH_URL = getattr(cloudfiles, AUTH_URL)
-
     local_object_names = []
     create_count = 0
     upload_count = 0


### PR DESCRIPTION
When syncstatic is executed, there is an exception about the actual auth URL being used as the key for getattr. This is due to cumulus.settings already doing the update.
