### PR TITLE
fixes #41 bug in read()

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,3 +8,4 @@ Ordered by date of first contribution:
   Graham King
   Sebastian Annies
   Ferrix Hovi
+  Iván Raskovsky

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -288,8 +288,8 @@ class CloudFilesStorageFile(File):
 
     def read(self, num_bytes=None):
         if self._pos == self._get_size():
-            return None
-        if self._pos + num_bytes > self._get_size():
+            return ""
+        if num_bytes and self._pos + num_bytes > self._get_size():
             num_bytes = self._get_size() - self._pos
         data = self.file.read(size=num_bytes or -1, offset=self._pos)
         self._pos += len(data)


### PR DESCRIPTION
This small change fixes when `read()` is called without num_bytes.

It also changes the return value for when the file has been read from `None` to `""` as per http://docs.python.org/tutorial/inputoutput.html#methods-of-file-objects (end of second paragraph).
