### PR TITLE
Add support for custom headers

### DIFF
--- a/cumulus/management/commands/syncstatic.py
+++ b/cumulus/management/commands/syncstatic.py
@@ -7,6 +7,7 @@ import cloudfiles
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from cumulus.settings import CUMULUS
+from cumulus.storage import sync_headers
 
 class Command(BaseCommand):
     help = "Synchronizes static media to cloud files."
@@ -124,6 +125,7 @@ class Command(BaseCommand):
 
             if not self.test_run:
                 cloud_obj.load_from_filename(file_path)
+                sync_headers(cloud_obj)
             self.upload_count += 1
             if self.verbosity > 1:
                 print "Uploaded", cloud_obj.name

--- a/cumulus/settings.py
+++ b/cumulus/settings.py
@@ -13,7 +13,8 @@ CUMULUS = {
     'USE_SSL': False,
     'USERNAME': None,
     'STATIC_CONTAINER': None,
-    'FILTER_LIST': []
+    'FILTER_LIST': [],
+    'HEADERS': {}
 }
 
 if hasattr(settings, 'CUMULUS'):

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+import re
 from StringIO import StringIO
 
 import cloudfiles
@@ -9,6 +10,22 @@ from django.core.files import File
 from django.core.files.storage import Storage
 
 from .settings import CUMULUS
+
+
+HEADER_PATTERNS = tuple((re.compile(p), h) for p, h in CUMULUS.get('HEADERS', {}))
+
+
+def sync_headers(cloud_obj, headers={}, header_patterns=HEADER_PATTERNS):
+    if hasattr(cloud_obj, 'headers'):
+        matched_headers = {}
+        for pattern, pattern_headers in header_patterns:
+            if pattern.match(cloud_obj.name):
+                matched_headers = pattern_headers.copy()
+                break
+        matched_headers.update(headers)
+        if matched_headers != cloud_obj.headers:
+            cloud_obj.headers = matched_headers
+            cloud_obj.sync_metadata()
 
 
 class CloudFilesStorage(Storage):
@@ -130,6 +147,7 @@ class CloudFilesStorage(Storage):
             cloud_obj.content_type = mime_type
         cloud_obj.send(content)
         content.close()
+        sync_headers(cloud_obj)
         return name
 
     def delete(self, name):


### PR DESCRIPTION
I've added support for uploading files with custom headers based on a regex pattern.The primary use I have for this ATM is to set the Access-Control-Allow-Origin header on webfont files so that Firefox can use them.

Usage is to put a tuple of regex/header pairs in settings. The first to match is applied to the file on upload, either via syncstatic or using the storage.

```
CUMULUS = {
    'HEADERS': (
        (r'.*\.(eot|otf|woff|ttf)$', {
            'Access-Control-Allow-Origin': '*'
        }),
    )
}
```

The only catch is that this depends on functionality just added to python-cloudfiles about 3 months ago (https://github.com/rackspace/python-cloudfiles/commit/f6682600bc8a4c55b6818d9c53e2ac34da153b28), so it requires the github version until they roll a release. Until then I've set it up to silently skip if the storage_obj doesn't have a headers attribute.

Let me know what you think. I can whip up some tests and docs if you like it.
