### PR TITLE
Allow importing the cumulus module without configuring it

### DIFF
--- a/cumulus/settings.py
+++ b/cumulus/settings.py
@@ -23,7 +23,7 @@ if hasattr(settings, 'CUMULUS'):
 CUMULUS['AUTH_URL'] = getattr(cloudfiles, CUMULUS['AUTH_URL'])
 
 # backwards compatibility for old-style cumulus settings
-if not hasattr(settings, 'CUMULUS'):
+if not hasattr(settings, 'CUMULUS') and hasattr(settings, 'CUMULUS_API_KEY'):
     import warnings
     warnings.warn(
         "settings.CUMULUS_* is deprecated; use settings.CUMULUS instead.",


### PR DESCRIPTION
I'm using cumulus in production only but still need to import it in development (other code inherits from it). Easy fix, please see the commit.
