### PR TITLE
Fixed documentation - changed USE_SERVICENET to SERVICENET

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,7 +108,7 @@ Add the following required settings::
 
     CUMULUS = {
         'STATIC_CONTAINER': 'MyStaticContainer', # the name of the container to sync with
-        'USE_SERVICENET': False, # whether to use rackspace's internal private network
+        'SERVICENET': False, # whether to use rackspace's internal private network
         'FILTER_LIST': [] # a list of files to exclude from sync
     }
 


### PR DESCRIPTION
There is no such key in default settings dict (https://github.com/khalas/django-cumulus/blob/master/cumulus/settings.py#L11)
