### PR TITLE
Fix infinite loop

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -158,7 +158,9 @@ class CloudFilesStorage(Storage):
         (called ``name``).
         """
         (path, last) = os.path.split(name)
-        if path:
+ 
+        # Avoid infinite loop if path is '/'
+        if path and path != '/':
             try:
                 self.container.get_object(path)
             except NoSuchObject:


### PR DESCRIPTION
If os.path.split is called with a path beginning from with a slash,
it will eventually return ('/', '') which will be looped back as '/'
which creates an infinite loop. Check for this condition. This is not
a nice fix and may cause another problem. Ref #53
