### PR TITLE
Fix collectstatic command

### DIFF
--- a/cumulus/management/commands/collectstatic.py
+++ b/cumulus/management/commands/collectstatic.py
@@ -21,4 +21,4 @@ class Command(collectstatic.Command):
                         return False
                 except:
                     raise
-        super(Command, self).delete_file(path, prefixed_path, source_storage)
+        return super(Command, self).delete_file(path, prefixed_path, source_storage)


### PR DESCRIPTION
`delete_file()` method should return a boolean, was missing a `return` when calling `super()`
