### PR TITLE
Use README.rst instead of .txt in MANIFEST.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE.txt
-include README.txt
+include README.rst
 recursive-include docs *
 recursive-exclude example *


### PR DESCRIPTION
Currently getting a warning: no files found matching 'README.txt' when installing.
