### PR TITLE
Also set pyrax identity_type for mgmt commands

### DIFF
--- a/cumulus/management/commands/container_create.py
+++ b/cumulus/management/commands/container_create.py
@@ -37,6 +37,8 @@ class Command(BaseCommand):
             print("Publish container: {0}".format(container_name))
             if CUMULUS["USE_PYRAX"]:
                 pyrax.set_credentials(CUMULUS["USERNAME"], CUMULUS["API_KEY"])
+                if CUMULUS["PYRAX_IDENTITY_TYPE"]:
+                    pyrax.set_setting("identity_type", CUMULUS["PYRAX_IDENTITY_TYPE"])
                 public = not CUMULUS["SERVICENET"]
                 connection = pyrax.connect_to_cloudfiles(region=CUMULUS["REGION"],
                                                          public=public)

--- a/cumulus/management/commands/container_info.py
+++ b/cumulus/management/commands/container_info.py
@@ -55,6 +55,8 @@ class Command(BaseCommand):
         for container_name, values in containers.iteritems():
             if CUMULUS["USE_PYRAX"]:
                 pyrax.set_credentials(CUMULUS["USERNAME"], CUMULUS["API_KEY"])
+                if CUMULUS["PYRAX_IDENTITY_TYPE"]:
+                    pyrax.set_setting("identity_type", CUMULUS["PYRAX_IDENTITY_TYPE"])
                 public = not CUMULUS["SERVICENET"]
                 connection = pyrax.connect_to_cloudfiles(region=CUMULUS["REGION"],
                                                          public=public)

--- a/cumulus/management/commands/syncstatic.py
+++ b/cumulus/management/commands/syncstatic.py
@@ -102,6 +102,8 @@ class Command(NoArgsCommand):
                 raise
 
         if CUMULUS["USE_PYRAX"]:
+            if CUMULUS["PYRAX_IDENTITY_TYPE"]:
+                pyrax.set_setting("identity_type", CUMULUS["PYRAX_IDENTITY_TYPE"])
             public = not CUMULUS["SERVICENET"]
             pyrax.set_credentials(CUMULUS["USERNAME"], CUMULUS["API_KEY"])
             connection = pyrax.connect_to_cloudfiles(region=CUMULUS["REGION"],

--- a/cumulus/tests/__init__.py
+++ b/cumulus/tests/__init__.py
@@ -38,6 +38,8 @@ class CumulusTests(TestCase):
                                           document=self.document,
                                           custom=self.custom)
         pyrax.set_credentials(CUMULUS["USERNAME"], CUMULUS["API_KEY"])
+        if CUMULUS["PYRAX_IDENTITY_TYPE"]:
+            pyrax.set_setting("identity_type", CUMULUS["PYRAX_IDENTITY_TYPE"])
         self.public = not CUMULUS["SERVICENET"]  # invert
         self.connection = pyrax.connect_to_cloudfiles(region=CUMULUS["REGION"],
                                                       public=self.public)


### PR DESCRIPTION
The recent feature to upgrade pyrax and add identity_type only set it in storage.py, it also needs to be set in management commands.
