### PR TITLE
Enable cumulus with non-rackspace openstack (but using pyrax).

### DIFF
--- a/cumulus/management/commands/container_delete.py
+++ b/cumulus/management/commands/container_delete.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
             raise CommandError("Pass one and only one [container_name] as an argument")
         container_name = args[0]
         if not options.get("is_yes"):
-            is_ok = input("Permanently delete container {0}? [y|N]".format(container_name))
+            is_ok = raw_input("Permanently delete container {0}? [y|N] ".format(
+                container_name))
             if not is_ok == "y":
                 raise CommandError("Aborted")
 

--- a/cumulus/settings.py
+++ b/cumulus/settings.py
@@ -8,6 +8,7 @@ CUMULUS = {
     "AUTH_URL": "us_authurl",
     "AUTH_VERSION": "1.0",
     "AUTH_TENANT_NAME": None,
+    "AUTH_TENANT_ID": None,
     "REGION": "DFW",
     "CNAMES": None,
     "CONTAINER": None,

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -81,6 +81,11 @@ class SwiftclientStorage(Storage):
         if CUMULUS["USE_PYRAX"]:
             if CUMULUS["PYRAX_IDENTITY_TYPE"]:
                 pyrax.set_setting("identity_type", CUMULUS["PYRAX_IDENTITY_TYPE"])
+            if CUMULUS["AUTH_URL"]:
+                pyrax.set_setting("auth_endpoint", CUMULUS["AUTH_URL"])
+            if CUMULUS["AUTH_TENANT_ID"]:
+                pyrax.set_setting("tenant_id", CUMULUS["AUTH_TENANT_ID"])
+
             pyrax.set_credentials(self.username, self.api_key)
 
     def __getstate__(self):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,6 +194,8 @@ Below are the default settings::
     CUMULUS = {
         'API_KEY': None,
         'AUTH_URL': 'us_authurl',
+        'AUTH_TENANT_NAME': None,
+        'AUTH_TENANT_ID': None,
         'CNAMES': None,
         'CONTAINER': None,
         'SERVICENET': False,
@@ -218,7 +220,13 @@ API_KEY
 AUTH_URL
 --------
 
-Set this to the region your account is in. Valid values are ``us_authurl`` (default) and ``uk_authurl``.
+Set this to the region your account is in. Valid values are ``us_authurl`` (default) and ``uk_authurl``,
+or if you are not using rackspace, your swift auth url.
+
+AUTH_TENANT_NAME and AUTH_TENANT_ID
+-----------------------------------
+
+Required if you are using your own Openstack Swift rather than rackspaces.
 
 REGION
 ------
@@ -314,6 +322,8 @@ USE_PYRAX
 
 If True, will use the Official Rackspace's Python SDK for OpenStack/Rackspace
 APIs. Defaults to True.
+
+Note: Currently this is required even to use your own OpenStack Swift setup.
 
 PYRAX_IDENTITY_TYPE
 -------------------


### PR DESCRIPTION
As per discussion with @richleland and @ferrix ,I'd like to use django-cumulus with my own openstack/swift/keystone infrastructure - and it seems that support for non-rackspace swift has eroded a bit in django-cumulus. This is my attempt to start bringing it back in :-).

Note: I think there was some confusion when I commented on richleland/django-cumulus#101 - this branch doesn't enable connecting to openstack without pyrax - it enables connecting to a non-rackspace swift+keystone using pyrax. Getting the non-pyrax option working looked like a bigger job than I had time for (plus, I think there needs to be an architectural decision there before it is fixed - perhaps using composition to enable extra functionality like the rackspace cdn support).

So the the two main issues were:
- Extra settings required for pyrax.set_setting (tenant_id and auth_url) when using non-rackspace swift
- pyrax assuming cdn availability whenever pyrax is used (I've also created a pull-request to fix that upstream, at https://github.com/rackspace/pyrax/pull/254 but provided a work-around here).

With that, I'm able to use the storage and run the management commands, and with some effort, get the current integration tests passing (separately) with non-rackspace swift: https://gist.github.com/absoludity/7689297

I've also tried to rework the container commands to be more general, and only branch to pyrax-only code for cdn-related functionality.
