### PR TITLE
Ignore PyCharm project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.py[co]
 .coverage
 .tox
+.idea
 MANIFEST
 _build/
 build/


### PR DESCRIPTION
PyCharm offers to add project files to this repository even they don't
really belong here.
