### PR TITLE
add object metadata using the HEADERS setting

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -199,7 +199,6 @@ class SwiftclientStorage(Storage):
             content_encoding = None
 
         if CUMULUS["USE_PYRAX"]:
-            # TODO set headers
             if content_encoding == "gzip":
                 content = get_gzipped_contents(content)
             self.connection.store_object(container=self.container_name,
@@ -208,6 +207,16 @@ class SwiftclientStorage(Storage):
                                          content_type=content_type,
                                          content_encoding=content_encoding,
                                          etag=None)
+            if CUMULUS["HEADERS"]:
+                # set headers/object metadata
+                metadata = {}
+                for pattern, pattern_headers in HEADER_PATTERNS:
+                    if pattern.match(name):
+                        metadata.update(pattern_headers.copy())
+                self.connection.set_object_metadata(container=self.container_name,
+                                                    obj=name,
+                                                    metadata=metadata,
+                                                    prefix='')
         else:
             # TODO gzipped content when using swift client
             self.connection.put_object(self.container_name, name,


### PR DESCRIPTION
#130: Add the object metadata using the existing `HEADERS` setting, eg:

``` python
# Set headers based on a regular expression in the file name. For example, this can be
# used to allow Firefox to access webfonts across domains.
'HEADERS': (
    (r'.*\.(ttf|otf|eot|woff|svg)$', {
        # Origins to be allowed to make Cross Origin Requests, space separated.
        'Access-Control-Allow-Origin': '*',
        # Max age for the Origin to hold the preflight results.
        'Access-Control-Max-Age': '360'
    }),
)
```
