### PR TITLE
use full_listing=True to make sure that we don't lose objects in big containers

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -166,7 +166,7 @@ class SwiftclientStorage(Storage):
         """
         Helper function to retrieve the requested Object.
         """
-        if name not in self.container.get_object_names():
+        if name not in self.container.get_object_names(full_listing=True):
             return False
         else:
             return self.container.get_object(name)


### PR DESCRIPTION
Fixes issue #140
