### PR TITLE
prevent unexpected file deletion

### DIFF
--- a/cumulus/settings.py
+++ b/cumulus/settings.py
@@ -28,7 +28,7 @@ CUMULUS = {
     "GZIP_CONTENT_TYPES": [],
     "USE_PYRAX": True,
     "PYRAX_IDENTITY_TYPE": None,
-    "FILE_TTL": CFClient.default_cdn_ttl
+    "FILE_TTL": None
 }
 
 if hasattr(settings, "CUMULUS"):


### PR DESCRIPTION
I finally found the reason for the sudden removal of files from the CDN.
There are "X-Delete-At/After" headers in the CloudFiles, which does the next thing:

> Objects that are assigned the X-Delete-At or X-Delete-After header are deleted within one day of the expiration time, and the object stops being served immediately after the expiration time.
> (http://docs.rackspace.com/files/api/v1/cf-devguide/content/Expiring_Objects-e1e3228.html)

"FILE_TTL" value is passed to "CFClient.store_object()" method, which sets "X-Delete-After" header for non-None values.

https://github.com/django-cumulus/django-cumulus/blob/master/cumulus/storage.py#L227

``` python
...
class SwiftclientStorage(Storage):
    ...
    def _save(self, name, content):
        ...
        self.connection.store_object(container=self.container_name,
                                         obj_name=name,
                                         data=content.read(),
                                         content_type=content_type,
                                         content_encoding=headers.get("Content-Encoding", None),
                                         ttl=CUMULUS["FILE_TTL"],
                                         etag=None)
...
```

https://github.com/rackspace/pyrax/blob/master/pyrax/cf_wrapper/client.py#L702

``` python
...
class CFClient(object):
    ...
    def store_object(self, container, obj_name, data, content_type=None,
            etag=None, content_encoding=None, ttl=None, return_none=False,
            chunk_size=None, headers=None, extra_info=None):
        ...
        if ttl is not None:
            headers["X-Delete-After"] = ttl
...
```

It is destructive and not obvious. The default value must be `None`, rather than `CFClient.default_cdn_ttl`.
