### PR TITLE
Cache result of URI

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -180,7 +180,7 @@ class SwiftclientStorage(Storage):
     container = property(_get_container, _set_container)
 
     def _get_container_url(self):
-        public_container_uri = cache.get('cloud_public_container_uri')
+        public_container_uri = cache.get('uri-' + self.container_name)
         if not public_container_uri:
             if self.use_ssl and self.container_ssl_uri:
                 self._container_public_uri = self.container_ssl_uri
@@ -193,7 +193,7 @@ class SwiftclientStorage(Storage):
             if CUMULUS["CNAMES"] and self._container_public_uri in CUMULUS["CNAMES"]:
                 self._container_public_uri = CUMULUS["CNAMES"][self._container_public_uri]
             public_container_uri = self._container_public_uri
-            cache.set('cloud_public_container_uri', public_container_uri)
+            cache.set('uri-' + self.container_name, public_container_uri)
         return public_container_uri
 
     container_url = property(_get_container_url)


### PR DESCRIPTION
This pull request will make it so the storage engine can cache the process of getting its URI. This is needed for a couple of reasons.

1. It will make non cached pages faster so we dont need to do network lookup to fetch the url if it has already been looked up once. This is most used in cases of media on the admin. If we have over 100 thumbnails to fetch for the admin this can take to much time and can even time out the browser.

2. If the API goes down and the service is still up our app should not go down because of it. // This might still happen since the ```_get_object``` method is still calling the API instead of caching the result after the first time its called for a unique name.