### PR TITLE
require newer version of pyrax

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -407,7 +407,7 @@ Requirements
 ************
 
 * Django>=1.2
-* pyrax>1.5,<1.9
+* pyrax>1.9,<1.10
 
 
 Tests

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version=__import__("cumulus").get_version().replace(" ", "-"),
     packages=find_packages(),
     install_requires=[
-        "pyrax>1.5,<1.9",
+        "pyrax>1.9,<1.10",
     ],
     author="Ferrix Hovi, Thomas Schreiber",
     license="BSD",

--- a/tox.ini
+++ b/tox.ini
@@ -17,54 +17,54 @@ setenv = PYTHONPATH = {toxinidir}/example
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.4,<1.6
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py26-django14]
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.3,<1.5
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py26-django13]
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.2,<1.4
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py26-django12]
 commands = django-admin.py test cumulus --settings=settings.legacy
 deps =
     Django>1.1,<1.3
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py27-django15]
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.4,<1.6
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py27-django14]
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.3,<1.5
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py27-django13]
 commands = django-admin.py test cumulus --settings=settings.test
 deps =
     Django>1.2,<1.4
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow
 
 [testenv:py27-django12]
 commands = django-admin.py test cumulus --settings=settings.legacy
 deps =
     Django>1.1,<1.3
-    pyrax>1.5,<1.9
+    pyrax>1.9,<1.10
     Pillow


### PR DESCRIPTION
There are critical upstream bugfixes that are in pyrax 1.9
Most importantly, celery processes are long-lived days on end, but pyrax
auth was timing out at 24 hours, causing auth issues.
