### PR TITLE
Fix error from readthedocs.org

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -378,7 +378,7 @@ access webfonts across domains::
 GZIP_CONTENT_TYPES
 ------------------
 
-Set which content types must be gzipped before sent to the cloud:
+Set which content types must be gzipped before sent to the cloud::
 
     CUMULUS = {
         'GZIP_CONTENT_TYPES': ['image/jpeg', 'text/css'],


### PR DESCRIPTION
```
/latest/docs/index.rst:385: WARNING: Definition list ends without
a blank line; unexpected unindent.
```
