### PR TITLE
 Closes #174 - Log pyrax errors, so as not to take down the entire site.

### DIFF
--- a/cumulus/authentication.py
+++ b/cumulus/authentication.py
@@ -1,3 +1,4 @@
+import logging
 import pyrax
 try:
     import swiftclient
@@ -44,7 +45,10 @@ class Auth(object):
             if self.auth_tenant_id:
                 self.pyrax.set_setting("tenant_id", self.auth_tenant_id)
             self.pyrax.set_setting("region", self.region)
-            self.pyrax.set_credentials(self.username, self.api_key)
+            try:
+                self.pyrax.set_credentials(self.username, self.api_key)
+            except Exception as e:
+                logging.exception("Pyrax Connect Error")
         # else:
         #     headers = {"X-Container-Read": ".r:*"}
         #     self._connection.post_container(self.container_name, headers=headers)


### PR DESCRIPTION
Images actually can be served by the CDN if pyrax is down. Log the exception, but fail gracefully so as not to take down the entire site.
