### PR TITLE
Clear headers

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -120,7 +120,8 @@ class SwiftclientStorage(Auth, Storage):
             self.connection.set_object_metadata(container=self.container_name,
                                                 obj=name,
                                                 metadata=headers,
-                                                prefix='')
+                                                prefix='',
+                                                clear=True)
         else:
             # TODO gzipped content when using swift client
             self.connection.put_object(self.container_name, name,


### PR DESCRIPTION
After upgrading to pyrax 1.9.3 the `HEADERS` option stopped working. [This comment](https://github.com/rackspace/pyrax/issues/364#issuecomment-58927242) suggests you (now) need to use `clear=True` to ensure you are not sending headers that will cause the server to ignore your request. A [full description](https://github.com/rackspace/pyrax/issues/364#issuecomment-59079386) of the problem can also be found there.
