### PR TITLE
Rename file storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ django-cumulus
 
 ``django-cumulus`` provides a set of tools to utilize the
 `python-swiftclient`_ and `Rackspace Cloud Files API`_ from Django. It
-includes a custom file storage class, SwiftclientFilesStorage.
+includes a custom file storage class, CumulusFilesStorage.
 
 |docs|_
 |build|_
@@ -64,7 +64,7 @@ Please visit `django-cumulus.readthedocs.org`_ for the full documentation.
         'CONTAINER': 'ContainerName',
         'PYRAX_IDENTITY_TYPE': 'rackspace',
     }
-    DEFAULT_FILE_STORAGE = 'cumulus.storage.SwiftclientStorage'
+    DEFAULT_FILE_STORAGE = 'cumulus.storage.CumulusStorage'
 
 The ``PYRAX_IDENTITY_TYPE`` parameter can either be ``rackspace`` or ``keystone``
 depending on whether you use Rackspace or OpenStack respectively.

--- a/cumulus/context_processors.py
+++ b/cumulus/context_processors.py
@@ -2,7 +2,7 @@ from urlparse import urlparse
 
 from django.conf import settings
 
-from cumulus.storage import SwiftclientStorage, SwiftclientStaticStorage
+from cumulus.storage import CumulusStorage, CumulusStaticStorage
 
 
 def _is_ssl_uri(uri):
@@ -20,7 +20,7 @@ def cdn_url(request):
     """
     A context processor that exposes the full CDN URL in templates.
     """
-    cdn_url, ssl_url = _get_container_urls(SwiftclientStorage())
+    cdn_url, ssl_url = _get_container_urls(CumulusStorage())
     static_url = settings.STATIC_URL
 
     return {
@@ -34,7 +34,7 @@ def static_cdn_url(request):
     A context processor that exposes the full static CDN URL
     as static URL in templates.
     """
-    cdn_url, ssl_url = _get_container_urls(SwiftclientStaticStorage())
+    cdn_url, ssl_url = _get_container_urls(CumulusStaticStorage())
     static_url = settings.STATIC_URL
 
     return {

--- a/cumulus/management/commands/collectstatic.py
+++ b/cumulus/management/commands/collectstatic.py
@@ -2,7 +2,7 @@ import hashlib
 
 from django.contrib.staticfiles.management.commands import collectstatic
 
-from cumulus.storage import SwiftclientStorage
+from cumulus.storage import CumulusStorage
 
 
 class Command(collectstatic.Command):
@@ -11,7 +11,7 @@ class Command(collectstatic.Command):
         """
         Checks if the target file should be deleted if it already exists
         """
-        if isinstance(self.storage, SwiftclientStorage):
+        if isinstance(self.storage, CumulusStorage):
             if self.storage.exists(prefixed_path):
                 try:
                     etag = self.storage._get_object(prefixed_path).etag

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -1,6 +1,7 @@
 import mimetypes
 import pyrax
 import re
+import warnings
 from gzip import GzipFile
 
 try:
@@ -261,10 +262,19 @@ class ThreadSafeCumulusStorage(CumulusStorage):
     container = property(_get_container, CumulusStorage._set_container)
 
 
-"""
-Keep the following Swiftclient storage classes around for
-backwards import compatibility.
-"""
-SwiftclientStaticStorage = CumulusStaticStorage
-SwiftclientStorage = CumulusStorage
-ThreadSafeSwiftclientStorage = ThreadSafeCumulusStorage
+class SwiftclientStorage(CumulusStorage):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("SwiftclientStorage is deprecated and will be removed in django-cumulus==1.3: \
+                       Use CumulusStorage instead.", DeprecationWarning)
+
+
+class SwiftclientStaticStorage(CumulusStaticStorage):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("SwiftclientStaticStorage is deprecated and will be removed in django-cumulus==1.3: \
+                       Use CumulusStaticStorage instead.", DeprecationWarning)
+
+
+class ThreadSafeSwiftclientStorage(ThreadSafeCumulusStorage):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("ThreadSafeSwiftclientStorage is deprecated and will be removed in django-cumulus==1.3: \
+                       Use threadsafeswiftclientstorage instead.", DeprecationWarning)

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -261,6 +261,10 @@ class ThreadSafeCumulusStorage(CumulusStorage):
     container = property(_get_container, CumulusStorage._set_container)
 
 
+"""
+Keep the following Swiftclient storage classes around for
+backwards import compatibility.
+"""
 SwiftclientStaticStorage = CumulusStaticStorage
 SwiftclientStorage = CumulusStorage
 ThreadSafeSwiftclientStorage = ThreadSafeCumulusStorage

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -266,15 +266,18 @@ class SwiftclientStorage(CumulusStorage):
     def __init__(self, *args, **kwargs):
         warnings.warn("SwiftclientStorage is deprecated and will be removed in django-cumulus==1.3: \
                        Use CumulusStorage instead.", DeprecationWarning)
+        super(SwiftclientStorage, self).__init__()
 
 
 class SwiftclientStaticStorage(CumulusStaticStorage):
     def __init__(self, *args, **kwargs):
         warnings.warn("SwiftclientStaticStorage is deprecated and will be removed in django-cumulus==1.3: \
                        Use CumulusStaticStorage instead.", DeprecationWarning)
+        super(SwiftclientStaticStorage, self).__init__()
 
 
 class ThreadSafeSwiftclientStorage(ThreadSafeCumulusStorage):
     def __init__(self, *args, **kwargs):
         warnings.warn("ThreadSafeSwiftclientStorage is deprecated and will be removed in django-cumulus==1.3: \
                        Use ThreadSafeCumulusStorage instead.", DeprecationWarning)
+        super(ThreadSafeSwiftclientStorage, self).__init__()

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -277,4 +277,4 @@ class SwiftclientStaticStorage(CumulusStaticStorage):
 class ThreadSafeSwiftclientStorage(ThreadSafeCumulusStorage):
     def __init__(self, *args, **kwargs):
         warnings.warn("ThreadSafeSwiftclientStorage is deprecated and will be removed in django-cumulus==1.3: \
-                       Use threadsafeswiftclientstorage instead.", DeprecationWarning)
+                       Use ThreadSafeCumulusStorage instead.", DeprecationWarning)

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -80,9 +80,9 @@ def get_gzipped_contents(input_file):
     return ContentFile(zbuf.getvalue())
 
 
-class SwiftclientStorage(Auth, Storage):
+class CumulusStorage(Auth, Storage):
     """
-    Custom storage for Swiftclient.
+    Custom storage for Cumulus.
     """
     default_quick_listdir = True
     container_name = CUMULUS["CONTAINER"]
@@ -94,13 +94,13 @@ class SwiftclientStorage(Auth, Storage):
 
     def _open(self, name, mode="rb"):
         """
-        Returns the SwiftclientStorageFile.
+        Returns the CumulusStorageFile.
         """
         return ContentFile(self._get_object(name).get())
 
     def _save(self, name, content):
         """
-        Uses the Swiftclient service to write ``content`` to a remote
+        Uses the Cumulus service to write ``content`` to a remote
         file (called ``name``).
         """
         content_type = get_content_type(name, content.file)
@@ -211,25 +211,25 @@ class SwiftclientStorage(Auth, Storage):
         return (dirs, files)
 
 
-class SwiftclientStaticStorage(SwiftclientStorage):
+class CumulusStaticStorage(CumulusStorage):
     """
-    Subclasses SwiftclientStorage to automatically set the container
+    Subclasses CumulusStorage to automatically set the container
     to the one specified in CUMULUS["STATIC_CONTAINER"]. This provides
     the ability to specify a separate storage backend for Django's
     collectstatic command.
 
     To use, make sure CUMULUS["STATIC_CONTAINER"] is set to something other
     than CUMULUS["CONTAINER"]. Then, tell Django's staticfiles app by setting
-    STATICFILES_STORAGE = "cumulus.storage.SwiftclientStaticStorage".
+    STATICFILES_STORAGE = "cumulus.storage.CumulusStaticStorage".
     """
     container_name = CUMULUS["STATIC_CONTAINER"]
     container_uri = CUMULUS["STATIC_CONTAINER_URI"]
     container_ssl_uri = CUMULUS["STATIC_CONTAINER_SSL_URI"]
 
 
-class ThreadSafeSwiftclientStorage(SwiftclientStorage):
+class ThreadSafeCumulusStorage(CumulusStorage):
     """
-    Extends SwiftclientStorage to make it mostly thread safe.
+    Extends CumulusStorage to make it mostly thread safe.
 
     As long as you do not pass container or cloud objects between
     threads, you will be thread safe.
@@ -237,7 +237,7 @@ class ThreadSafeSwiftclientStorage(SwiftclientStorage):
     Uses one connection/container per thread.
     """
     def __init__(self, *args, **kwargs):
-        super(ThreadSafeSwiftclientStorage, self).__init__(*args, **kwargs)
+        super(ThreadSafeCumulusStorage, self).__init__(*args, **kwargs)
 
         import threading
         self.local_cache = threading.local()
@@ -249,7 +249,7 @@ class ThreadSafeSwiftclientStorage(SwiftclientStorage):
 
         return self.local_cache.connection
 
-    connection = property(_get_connection, SwiftclientStorage._set_connection)
+    connection = property(_get_connection, CumulusStorage._set_connection)
 
     def _get_container(self):
         if not hasattr(self.local_cache, "container"):
@@ -258,4 +258,9 @@ class ThreadSafeSwiftclientStorage(SwiftclientStorage):
 
         return self.local_cache.container
 
-    container = property(_get_container, SwiftclientStorage._set_container)
+    container = property(_get_container, CumulusStorage._set_container)
+
+
+SwiftclientStaticStorage = CumulusStaticStorage
+SwiftclientStorage = CumulusStorage
+ThreadSafeSwiftclientStorage = ThreadSafeCumulusStorage

--- a/cumulus/tests/__init__.py
+++ b/cumulus/tests/__init__.py
@@ -5,11 +5,11 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from cumulus.settings import CUMULUS
-from cumulus.storage import SwiftclientStorage
+from cumulus.storage import CumulusStorage
 from cumulus.tests.models import Thing
 
 
-openstack_storage = SwiftclientStorage()
+openstack_storage = CumulusStorage()
 
 
 class CumulusTests(TestCase):

--- a/cumulus/tests/models.py
+++ b/cumulus/tests/models.py
@@ -1,8 +1,8 @@
 from django.db import models
 
-from cumulus.storage import SwiftclientStorage
+from cumulus.storage import CumulusStorage
 
-openstack_storage = SwiftclientStorage()
+openstack_storage = CumulusStorage()
 
 
 class Thing(models.Model):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 changelog
 =========
 
+Version 1.2, (in progress)
+********************************
+
+* Revive the changelog
+* Rename legacy SwiftclientStorage to CumulusStorage (keeping backwards compatibility)
+
+
 Version 1.0.13, 1 September 2014
 ********************************
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ django-cumulus |version|
 
 ``django-cumulus`` provides a set of tools to utilize the
 `python-swiftclient`_ and `Rackspace Cloud Files API`_ from Django. It
-includes a custom file storage class, SwiftclientFilesStorage.
+includes a custom file storage class, CumulusFilesStorage.
 
 More documentation about the usage and installation of ``django-cumulus``
 can be found on `django-cumulus.readthedocs.org`_.
@@ -53,7 +53,7 @@ Add the following to your project's settings.py file::
         'CONTAINER': 'ContainerName',
         'PYRAX_IDENTITY_TYPE': 'rackspace',
     }
-    DEFAULT_FILE_STORAGE = 'cumulus.storage.SwiftclientStorage'
+    DEFAULT_FILE_STORAGE = 'cumulus.storage.CumulusStorage'
 
 The ``PYRAX_IDENTITY_TYPE`` parameter can either be ``rackspace`` or ``keystone``
 depending on whether you use Rackspace or OpenStack respectively.
@@ -61,9 +61,9 @@ depending on whether you use Rackspace or OpenStack respectively.
 Alternatively, if you don't want to set the DEFAULT_FILE_STORAGE, you
 can do the following in your models::
 
-    from cumulus.storage import SwiftclientStorage
+    from cumulus.storage import CumulusStorage
 
-    swiftclient_storage = SwiftclientStorage()
+    swiftclient_storage = CumulusStorage()
 
     class Photo(models.Model):
         image = models.ImageField(storage=swiftclient_storage, upload_to='photos')
@@ -94,7 +94,7 @@ settings::
     CUMULUS = {
         'STATIC_CONTAINER': 'YourStaticContainer'
     }
-    STATICFILES_STORAGE = 'cumulus.storage.SwiftclientStaticStorage'
+    STATICFILES_STORAGE = 'cumulus.storage.CumulusStaticStorage'
 
 
 Context Processor
@@ -103,7 +103,7 @@ Context Processor
 ``django-cumulus`` includes an optional context_processor for accessing
 the full CDN_URL of any container files from your templates.
 
-This is useful when you're using Swiftclient to serve you static media
+This is useful when you're using Cumulus to serve you static media
 such as css and javascript and don't have access to the ``ImageField``
 or ``FileField``'s url() convenience method.
 

--- a/example/settings/common.py
+++ b/example/settings/common.py
@@ -152,8 +152,8 @@ LOGGING = {
     }
 }
 
-DEFAULT_FILE_STORAGE = 'cumulus.storage.SwiftclientStorage'
-#STATICFILES_STORAGE = 'cumulus.storage.SwiftclientStaticStorage'
+DEFAULT_FILE_STORAGE = 'cumulus.storage.CumulusStorage'
+#STATICFILES_STORAGE = 'cumulus.storage.CumulusStaticStorage'
 
 # these are the default cumulus settings
 CUMULUS = {


### PR DESCRIPTION
The storage classes were named after Swiftclient at one point in time, before switching to Pyrax. Lets keep it generic and base it off Cumulus to avoid confusion.

* Keep the following Swiftclient storage classes around for backwards import compatibility.