### PR TITLE
Add caching to authentication and clean up the file.

### DIFF
--- a/cumulus/management/commands/container_create.py
+++ b/cumulus/management/commands/container_create.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         if len(args) != 1:
             raise CommandError("Pass one and only one [container_name] as an argument")
 
-        self._connection = Auth()._get_connection()
+        self._connection = Auth().connection()
 
         container_name = args[0]
         print("Creating container: {0}".format(container_name))

--- a/cumulus/management/commands/container_delete.py
+++ b/cumulus/management/commands/container_delete.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
                 raise CommandError("Aborted")
 
         print("Connecting")
-        self._connection = Auth()._get_connection()
+        self._connection = Auth().connection()
         container = self._connection.get_container(container_name)
         print("Deleting objects from container {0}".format(container_name))
         container.delete_all_objects()

--- a/cumulus/management/commands/container_info.py
+++ b/cumulus/management/commands/container_info.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        self._connection = Auth()._get_connection()
+        self._connection = Auth().connection()
 
         container_names = self._connection.list_container_names()
 

--- a/cumulus/management/commands/container_list.py
+++ b/cumulus/management/commands/container_list.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         """
         Lists all the items in a container to stdout.
         """
-        self._connection = Auth()._get_connection()
+        self._connection = Auth().connection()
 
         if len(args) == 0:
             containers = self._connection.list_containers()

--- a/cumulus/management/commands/syncfiles.py
+++ b/cumulus/management/commands/syncfiles.py
@@ -100,7 +100,7 @@ class Command(NoArgsCommand):
     def handle_noargs(self, *args, **options):
         # setup
         self.set_options(options)
-        self._connection = Auth()._get_connection()
+        self._connection = Auth().connection()
         self.container = self._connection.get_container(self.container_name)
 
         # wipe first

--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-from django.core.files.base import File, ContentFile
+from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 
 from cumulus.authentication import Auth
@@ -86,8 +86,6 @@ class SwiftclientStorage(Auth, Storage):
     """
     default_quick_listdir = True
     container_name = CUMULUS["CONTAINER"]
-    container_uri = CUMULUS["CONTAINER_URI"]
-    container_ssl_uri = CUMULUS["CONTAINER_SSL_URI"]
     ttl = CUMULUS["TTL"]
     file_ttl = CUMULUS["FILE_TTL"]
     use_ssl = CUMULUS["USE_SSL"]
@@ -168,7 +166,7 @@ class SwiftclientStorage(Auth, Storage):
         Returns an absolute URL where the content of each file can be
         accessed directly by a web browser.
         """
-        return "{0}/{1}".format(self.container_url, name)
+        return "{0}/{1}".format(self.container_uri, name)
 
     def listdir(self, path):
         """
@@ -227,35 +225,8 @@ class SwiftclientStaticStorage(SwiftclientStorage):
     container_ssl_uri = CUMULUS["STATIC_CONTAINER_SSL_URI"]
 
 
-class ThreadSafeSwiftclientStorage(SwiftclientStorage):
-    """
-    Extends SwiftclientStorage to make it mostly thread safe.
-
-    As long as you do not pass container or cloud objects between
-    threads, you will be thread safe.
-
-    Uses one connection/container per thread.
-    """
-    def __init__(self, *args, **kwargs):
-        super(ThreadSafeSwiftclientStorage, self).__init__(*args, **kwargs)
-
-        import threading
-        self.local_cache = threading.local()
-
-    def _get_connection(self):
-        if not hasattr(self.local_cache, "connection"):
-            connection = self._get_connection()
-            self.local_cache.connection = connection
-
-        return self.local_cache.connection
-
-    connection = property(_get_connection, SwiftclientStorage._set_connection)
-
-    def _get_container(self):
-        if not hasattr(self.local_cache, "container"):
-            container = self.connection.create_container(self.container_name)
-            self.local_cache.container = container
-
-        return self.local_cache.container
-
-    container = property(_get_container, SwiftclientStorage._set_container)
+"""
+SwiftclientStorage now caches connection and container, keep
+ThreadSafeSwiftclientStorage importable for backwards compatibility.
+"""
+ThreadSafeSwiftclientStorage = SwiftclientStorage


### PR DESCRIPTION
Simplify our authentication by caching properties that ping the api. 

References #161