### PR TITLE
Cumulus breaks on non ascii object names

### DIFF
--- a/cumulus/storage.py
+++ b/cumulus/storage.py
@@ -169,7 +169,7 @@ class CumulusStorage(Auth, Storage):
         Returns an absolute URL where the content of each file can be
         accessed directly by a web browser.
         """
-        return "{0}/{1}".format(self.container_url, name)
+        return u"{0}/{1}".format(self.container_url, name)
 
     def listdir(self, path):
         """
@@ -181,7 +181,7 @@ class CumulusStorage(Auth, Storage):
         """
         files = []
         if path and not path.endswith("/"):
-            path = "{0}/".format(path)
+            path = u"{0}/".format(path)
         path_len = len(path)
         for name in [x["name"] for x in
                      self.connection.get_container(self.container_name, full_listing=True)[1]]:
@@ -197,7 +197,7 @@ class CumulusStorage(Auth, Storage):
         dirs = set()
         files = []
         if path and not path.endswith("/"):
-            path = "{0}/".format(path)
+            path = u"{0}/".format(path)
         path_len = len(path)
         for name in [x["name"] for x in
                      self.connection.get_container(self.container_name, full_listing=True)[1]]:


### PR DESCRIPTION
When requesting the url to an object with a non ascii name it breaks:

```
Traceback (most recent call last):
  File "/home/ivan/.virtualenvs/adoora/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 64, in __call__
    return self.application(environ, start_response)
  File "/home/ivan/.virtualenvs/adoora/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 187, in __call__
    response = self.get_response(request)
...
  File "/home/ivan/.virtualenvs/adoora/lib/python2.7/site-packages/django/db/models/fields/files.py", line 67, in _get_url
    return self.storage.url(self.name)
  File "/home/ivan/.virtualenvs/adoora/src/django-cumulus/cumulus/storage.py", line 172, in url
    return "{0}/{1}".format(self.container_url, name)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 31: ordinal not in range(128)
```