### PR TITLE
BaseCommand.option_list is deprecated since Django 1.10

### DIFF
--- a/cumulus/management/commands/container_create.py
+++ b/cumulus/management/commands/container_create.py
@@ -1,5 +1,3 @@
-import optparse
-
 from django.core.management.base import BaseCommand, CommandError
 
 from cumulus.authentication import Auth
@@ -10,9 +8,9 @@ class Command(BaseCommand):
     help = "Create a container."
     args = "[container_name]"
 
-    option_list = BaseCommand.option_list + (
-        optparse.make_option("-p", "--private", action="store_true", default=False,
-                             dest="private", help="Make a private container."),)
+    def add_arguments(self, parser):
+        parser.add_argument('-p', '--private', action='store_true', default=False,
+                            dest='private', help='Assume Yes to confiramtion question')
 
     def handle(self, *args, **options):
         if len(args) != 1:

--- a/cumulus/management/commands/container_delete.py
+++ b/cumulus/management/commands/container_delete.py
@@ -1,5 +1,3 @@
-import optparse
-
 from django.core.management.base import BaseCommand, CommandError
 
 from cumulus.authentication import Auth
@@ -9,9 +7,9 @@ class Command(BaseCommand):
     help = "Delete a container."
     args = "[container_name]"
 
-    option_list = BaseCommand.option_list + (
-        optparse.make_option("-y", "--yes", action="store_true", default=False,
-                             dest="is_yes", help="Assume Yes to confirmation question"),)
+    def add_arguments(self, parser):
+        parser.add_argument('-y', '--yes', action='store_true', default=False,
+                            dest='is_yes', help='Assume Yes to confiramtion question')
 
     def handle(self, *args, **options):
         if len(args) != 1:

--- a/cumulus/management/commands/container_info.py
+++ b/cumulus/management/commands/container_info.py
@@ -1,5 +1,3 @@
-import optparse
-
 from django.core.management.base import BaseCommand
 
 from cumulus.authentication import Auth
@@ -9,12 +7,11 @@ class Command(BaseCommand):
     help = "Display info for containers"
     args = "[container_name container_name ...]"
 
-    option_list = BaseCommand.option_list + (
-        optparse.make_option("-n", "--name", action="store_true", dest="name", default=False),
-        optparse.make_option("-c", "--count", action="store_true", dest="count", default=False),
-        optparse.make_option("-s", "--size", action="store_true", dest="size", default=False),
-        optparse.make_option("-u", "--uri", action="store_true", dest="uri", default=False)
-    )
+    def add_arguments(self, parser):
+        parser.add_argument("-n", "--name", action="store_true", dest="name", default=False),
+        parser.add_argument("-c", "--count", action="store_true", dest="count", default=False),
+        parser.add_argument("-s", "--size", action="store_true", dest="size", default=False),
+        parser.add_argument("-u", "--uri", action="store_true", dest="uri", default=False)
 
     def handle(self, *args, **options):
         self._connection = Auth()._get_connection()

--- a/cumulus/management/commands/syncfiles.py
+++ b/cumulus/management/commands/syncfiles.py
@@ -1,11 +1,10 @@
 import datetime
 import fnmatch
-import optparse
 import os
 import re
 
 from django.conf import settings
-from django.core.management.base import CommandError, NoArgsCommand
+from django.core.management.base import CommandError, BaseCommand
 
 
 from cumulus.authentication import Auth
@@ -13,35 +12,35 @@ from cumulus.settings import CUMULUS
 from cumulus.storage import get_headers, get_content_type, get_gzipped_contents
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Synchronizes project static *or* media files to cloud files."
-    option_list = NoArgsCommand.option_list + (
-        optparse.make_option("-i", "--include", action="append", default=[],
+
+    def add_arguments(self, parser):
+        parser.add_argument("-i", "--include", action="append", default=[],
                              dest="includes", metavar="PATTERN",
                              help="Include file or directories matching this glob-style "
                                   "pattern. Use multiple times to include more."),
-        optparse.make_option("-e", "--exclude", action="append", default=[],
+        parser.add_argument("-e", "--exclude", action="append", default=[],
                              dest="excludes", metavar="PATTERN",
                              help="Exclude files or directories matching this glob-style "
                                   "pattern. Use multiple times to exclude more."),
-        optparse.make_option("-w", "--wipe",
+        parser.add_argument("-w", "--wipe",
                              action="store_true", dest="wipe", default=False,
                              help="Wipes out entire contents of container first."),
-        optparse.make_option("-t", "--test-run",
+        parser.add_argument("-t", "--test-run",
                              action="store_true", dest="test_run", default=False,
                              help="Performs a test run of the sync."),
-        optparse.make_option("-q", "--quiet",
+        parser.add_argument("-q", "--quiet",
                              action="store_true", dest="test_run", default=False,
                              help="Do not display any output."),
-        optparse.make_option("-c", "--container",
+        parser.add_argument("-c", "--container",
                              dest="container", help="Override STATIC_CONTAINER."),
-        optparse.make_option("-s", "--static",
+        parser.add_argument("-s", "--static",
                              action="store_true", dest="syncstatic", default=False,
                              help="Sync static files located at settings.STATIC_ROOT path."),
-        optparse.make_option("-m", "--media",
+        parser.add_argument("-m", "--media",
                              action="store_true", dest="syncmedia", default=False,
                              help="Sync media files located at settings.MEDIA_ROOT path."),
-    )
 
     def set_options(self, options):
         """


### PR DESCRIPTION
Hi there, 

`BaseCommand.option_list` has been deprecated since Django 1.8 and was removed in 1.10. I don't use any of Django Cumulus's commands, but since django-cumulus is a dependency of our app and uses `option_list`, it is breaking other management commands (in Django 1.11).

This commit migrates the management command arguments from the old style to the new (using argparse). This is the bare minimum to prevent django-cumulus from raising an exception when other management commands are run, but I have not tested to see if these options still work as expected. This change also probably breaks support for Django <=1.7.

I know there hasn't been much recent activity on this. Django Cumulus is an old dependency of my app (since early 2014). Is this package still active? Is there a better alternative I should consider in 2017?

Thanks,
William
