### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ depending on whether you use Rackspace or OpenStack respectively.
 .. _build: http://travis-ci.org/#!/django-cumulus/django-cumulus
 .. |coverage| image:: https://coveralls.io/repos/django-cumulus/django-cumulus/badge.png?branch=master
 .. _coverage: https://coveralls.io/r/django-cumulus/django-cumulus
-.. |version| image:: https://pypip.in/v/django-cumulus/badge.png
+.. |version| image:: https://img.shields.io/pypi/v/django-cumulus.svg
 .. _version: https://crate.io/packages/django-cumulus
 .. |requires| image:: https://requires.io/github/django-cumulus/django-cumulus/requirements.png?branch=master
 .. _requires: https://requires.io/github/django-cumulus/django-cumulus/requirements/?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-cumulus))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-cumulus`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.